### PR TITLE
feat:layout 설정

### DIFF
--- a/client/src/app/globals.css
+++ b/client/src/app/globals.css
@@ -52,18 +52,23 @@
 
 :root {
   --background: #ffffff;
-  --foreground: #171717;
+  --foreground: #314855;
 }
 
 @media (prefers-color-scheme: dark) {
   :root {
-    --background: #0a0a0a;
+    --background: #314855;
     --foreground: #ededed;
   }
 }
 
 body {
-  color: var(--foreground);
+  display: flex;
+  justify-content: center;
+  @apply text-primary-navy;
   background: var(--background);
   font-family: 'Pretendard', 'sans-serif';
+  width: 100vw;
+  height: 100vh;
+  overflow: hidden;
 }

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -18,7 +18,11 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body>
-        <Providers>{children}</Providers>
+        <Providers>
+          <div className="bg-primary-white w-mobile screen:w-web h-full px-[2rem] py-[2rem]">
+            {children}
+          </div>
+        </Providers>
       </body>
       <Pwa />
     </html>

--- a/client/src/app/provider.tsx
+++ b/client/src/app/provider.tsx
@@ -1,6 +1,6 @@
 'use client';
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { PropsWithChildren, useState } from "react";
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { PropsWithChildren, useState } from 'react';
 
 const Providers = ({ children }: PropsWithChildren) => {
   const [client] = useState(
@@ -9,16 +9,12 @@ const Providers = ({ children }: PropsWithChildren) => {
         queries: {
           retry: false,
           staleTime: 60000
-        },
-      },
-    }),
+        }
+      }
+    })
   );
 
-  return (
-    <QueryClientProvider client={client}>
-      {children}
-    </QueryClientProvider>
-  )
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
 };
 
 export default Providers;

--- a/client/tailwind.config.ts
+++ b/client/tailwind.config.ts
@@ -2,15 +2,18 @@ import type { Config } from 'tailwindcss';
 
 export default {
   content: [
+    // Tailwind CSS가 적용될 파일 경로들
     './src/pages/**/*.{js,ts,jsx,tsx,mdx}',
     './src/components/**/*.{js,ts,jsx,tsx,mdx}',
     './src/app/**/*.{js,ts,jsx,tsx,mdx}'
   ],
   theme: {
     extend: {
+      // 사용자 정의 폰트 패밀리 설정
       fontFamily: {
         ganpan: ['KCC-Ganpan', 'sans-serif']
       },
+      // 사용자 정의 폰트 굵기 설정
       fontWeight: {
         extraBold: '800',
         bold: '700',
@@ -20,9 +23,10 @@ export default {
         light: '300',
         extraLight: '200'
       },
+      // 사용자 정의 색상 설정
       colors: {
-        background: 'var(--background)',
-        foreground: 'var(--foreground)',
+        background: 'var(--background)', // CSS 변수 사용
+        foreground: 'var(--foreground)', // CSS 변수 사용
         primary: {
           coral: '#E95F5C',
           mint: '#79CEB8',
@@ -32,90 +36,99 @@ export default {
           white: '#FFFFFF'
         }
       },
+      // 사용자 정의 너비 설정
       width: {
-        web: '46.875rem'
+        web: '46.875rem', // 750px
+        mobile: '30rem', // 480px
+        screen: '78.125rem' // 1250px
       },
+      // 최소 너비 설정
       minWidth: {
-        mobile: '21.875rem'
+        mobile: '21.875rem' // 350px
       },
+      // 배경색 설정
       backgroundColor: {
-        error: '#f5f5f5'
+        error: '#f5f5f5' // 에러 배경색
       },
+      // 반응형 디자인을 위한 화면 크기 설정
       screens: {
-        mobile: '375px',
+        mobile: '480px',
         web: '750px',
+        screen: '1250px',
         image: '530px'
       },
+      // 그림자 설정
       boxShadow: {
         top: '0 0 8px rgba(0, 0, 0, 0.08)',
         bottom: '0 0 8px rgba(0, 0, 0, 0.08)'
       },
+      // 폰트 크기 설정
       fontSize: {
         heading1: [
-          '1.5rem',
+          '1.5rem', // 24px
           {
             lineHeight: '1.3',
             fontWeight: '700'
           }
         ],
         heading2: [
-          '1.25rem',
+          '1.25rem', // 20px
           {
             lineHeight: '1.3',
             fontWeight: '700'
           }
         ],
         heading3: [
-          '1.125rem',
+          '1.125rem', // 18px
           {
             lineHeight: '1.4',
             fontWeight: '600'
           }
         ],
         body1: [
-          '1rem',
+          '1rem', // 16px
           {
             lineHeight: '1.6',
             fontWeight: '500'
           }
         ],
         body2: [
-          '.875rem',
+          '.875rem', // 14px
           {
             lineHeight: '1.6',
             fontWeight: '500'
           }
         ],
         body1Bold: [
-          '1rem',
+          '1rem', // 16px
           {
             lineHeight: '1.6',
             fontWeight: '700'
           }
         ],
         body2Bold: [
-          '.875rem',
+          '.875rem', // 14px
           {
             lineHeight: '1.6',
             fontWeight: '700'
           }
         ],
         button: [
-          '1rem',
+          '1rem', // 16px
           {
             lineHeight: '1.4',
             fontWeight: '600'
           }
         ],
         smallBtn: [
-          '.875rem',
+          '.875rem', // 14px
           {
             lineHeight: '1.4',
             fontWeight: '600'
           }
         ],
         caption: [
-          '.75rem',
+          '.75rem', // 12px
           {
             lineHeight: '1.4',
             fontWeight: '500'


### PR DESCRIPTION
## 💡 작업 내용

- [x] CSS 설정

## 💡 자세한 설명
### 🛠️ globals.css body 값 추가
중앙정렬 및 다크모드 시 완전 black 보다는 네이비 톤으로 변경
```css
@tailwind base;
@tailwind components;
@tailwind utilities;

@font-face {
  font-family: 'Pretendard';
  font-weight: 800;
  src: url('../fonts/Pretendard-ExtraBold.woff') format('woff');
}

@font-face {
  font-family: 'Pretendard';
  font-weight: 700;
  src: url('../fonts/Pretendard-Bold.woff');
}

@font-face {
  font-family: 'Pretendard';
  font-weight: 600;
  src: url('../fonts/Pretendard-SemiBold.woff');
}

@font-face {
  font-family: 'Pretendard';
  font-weight: 500;
  src: url('../fonts/Pretendard-Medium.woff');
}

@font-face {
  font-family: 'Pretendard';
  font-weight: 400;
  src: url('../fonts/Pretendard-Regular.woff');
}

@font-face {
  font-family: 'Pretendard';
  font-weight: 300;
  src: url('../fonts/Pretendard-Light.woff');
}

@font-face {
  font-family: 'Pretendard';
  font-weight: 200;
  src: url('../fonts/Pretendard-ExtraLight.woff');
}

@font-face {
  font-family: 'KCC-Ganpan';
  font-weight: 500;
  src: url('../fonts/KCC-Ganpan.woff') format('woff');
}

:root {
  --background: #ffffff;
  --foreground: #314855;
}

@media (prefers-color-scheme: dark) {
  :root {
    --background: #314855;
    --foreground: #ededed;
  }
}

body {
  display: flex;
  justify-content: center;
  @apply text-primary-navy;
  background: var(--background);
  font-family: 'Pretendard', 'sans-serif';
  width: 100vw;
  height: 100vh;
  overflow: hidden;
}

```

### 🛠️ layout.tsx 수정
Provider 안에 div를 설정하여 css를 입혀준다
```tsx
import { Metadata } from 'next';
import './globals.css';
import Providers from './provider';
import Pwa from './Pwa';

export const metadata: Metadata = {
  title: '프로들의 협곡을 실시간으로',
  icons: {
    icon: '/favicon.ico'
  }
};

export default async function RootLayout({
  children
}: Readonly<{
  children: React.ReactNode;
}>) {
  return (
    <html lang="en">
      <body>
        <Providers>
          <div className="bg-primary-white w-mobile screen:w-web h-full px-[2rem] py-[2rem]">
            {children}
          </div>
        </Providers>
      </body>
      <Pwa />
    </html>
  );
}



  <!-- 
    bg-primary-white: 
      - 'bg-'는 배경색을 설정하는 Tailwind의 기본 접두어입니다.
      - 'primary-white'는 tailwind.config.ts에서 설정한 커스텀 색상 값입니다. 
      - 즉, 이 div의 배경색을 `primary.white`로 설정합니다. (예: `#FFFFFF`)

    w-mobile: 
      - 'w-'는 width(너비)를 설정하는 Tailwind의 기본 접두어입니다.
      - 'mobile'은 `tailwind.config.ts`에서 정의한 사용자 정의 너비 값입니다.
      - 이 div의 너비는 `480px`(모바일 화면 크기)로 설정됩니다. (config에서 설정한 값)

    screen:w-web: 
      - 이 클래스는 `screen:web` 스크린 크기 이상에서만 적용됩니다. 
      - 'screen' 접두어는 Tailwind에서 사용자 정의 미디어 쿼리(`screens`)을 사용할 때 쓰며, 'w-web'은 `screen:web`으로 설정한 값(예: `750px`)을 기준으로 적용됩니다.
      - 즉, 화면 크기가 750px 이상일 때 너비가 `750px`로 설정됩니다.

    h-full: 
      - 'h-'는 height(높이)를 설정하는 Tailwind의 기본 접두어입니다.
      - 'full'은 `height: 100%`를 의미하며, 부모 요소의 높이에 맞춰 이 div의 높이를 100%로 설정합니다.

    px-[2rem]: 
      - 'px-'는 padding-left와 padding-right를 동시에 설정하는 Tailwind의 접두어입니다.
      - '[2rem]'은 고유한 값으로 `2rem`을 의미합니다. 즉, 좌우에 2rem만큼의 패딩이 적용됩니다.

    py-[2rem]: 
      - 'py-'는 padding-top과 padding-bottom을 동시에 설정하는 Tailwind의 접두어입니다.
      - '[2rem]'은 고유한 값으로 `2rem`을 의미합니다. 즉, 위아래에 2rem만큼의 패딩이 적용됩니다.
  -->

```

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호
