### PR TITLE
fix: 알림 2번 오는 오류 수정

### DIFF
--- a/client/public/firebase-messaging-sw.js
+++ b/client/public/firebase-messaging-sw.js
@@ -52,19 +52,17 @@ messaging.onBackgroundMessage((payload) => {
     payload
   );
 
-  // 푸시 알림으로 표시할 데이터 추출
-  // payload 구조: { notification: { title, body, icon, ... }, data: { custom_key: 'value' } }
-  const notificationTitle = payload.notification?.title || '새 알림';
-  const notificationOptions = {
-    body: payload.notification?.body || '내용 없음',
-    icon: payload.notification?.icon || '/icon-192x192.png', // 기본 아이콘 경로
-    badge: payload.notification?.badge || '/icon-192x192.png', // 기본 배지 아이콘 경로 (iOS)
-    image: payload.notification?.image || undefined, // 알림 내 이미지 URL
-    data: payload.data // 알림 클릭 시 전달할 추가 데이터
-    // vibration: [200, 100, 200], // 진동 패턴 (선택 사항)
-    // tag: 'my-notification-tag', // 알림 그룹화 (선택 사항)
-  };
+  const messageData = payload.data || {}; // data payload가 비어있을 경우를 대비
 
+  // 푸시 알림으로 표시할 데이터 추출
+  const notificationTitle = messageData.title || '새 알림';
+  const notificationOptions = {
+    body: messageData.body || '내용 없음',
+    icon: messageData.icon || '/icon-192x192.png',
+    badge: messageData.badge || '/icon-192x192.png',
+    image: messageData.image || undefined,
+    data: messageData // data payload 전체를 notificationOptions.data에 넣어줌 (클릭 핸들러에서 사용)
+  };
   // 푸시 알림 표시
   // event.waitUntil()을 사용하여 알림 표시 작업이 완료될 때까지 서비스 워커가 종료되지 않도록 함
   self.registration.showNotification(notificationTitle, notificationOptions);

--- a/supabase/functions/push/index.ts
+++ b/supabase/functions/push/index.ts
@@ -68,7 +68,7 @@ Deno.serve(async (req) => {
             const fcmBody = {
                 message: {
                     token: fcm_token,
-                    notification: {
+                    data: {
                         title: `ProQ-Noti`,
                         body: payload.record.body,
                     },


### PR DESCRIPTION
## 💡 작업 내용

- [x] 알람 중복 수정

## 💡 자세한 설명
#### 서비스워커 수정
```js
messaging.onBackgroundMessage((payload) => {
  console.log(
    '[firebase-messaging-sw.js] Received background message: ',
    payload
  );

  const messageData = payload.data || {}; // data payload가 비어있을 경우를 대비

  // 푸시 알림으로 표시할 데이터 추출
  const notificationTitle = messageData.title || '새 알림';
  const notificationOptions = {
    body: messageData.body || '내용 없음',
    icon: messageData.icon || '/icon-192x192.png',
    badge: messageData.badge || '/icon-192x192.png',
    image: messageData.image || undefined,
    data: messageData // data payload 전체를 notificationOptions.data에 넣어줌 (클릭 핸들러에서 사용)
  };
  // 푸시 알림 표시
  // event.waitUntil()을 사용하여 알림 표시 작업이 완료될 때까지 서비스 워커가 종료되지 않도록 함
  self.registration.showNotification(notificationTitle, notificationOptions);
});
```

#### push 서버 notification -> data로 변경
```ts
const fcmBody = {
                message: {
                    token: fcm_token,
                    data: {
                        title: `ProQ-Noti`,
                        body: payload.record.body,
                    },
                },
            };
```

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호
