### PR TITLE
bugfix: toast 중복 알림 제거

### DIFF
--- a/client/src/store/AuthProvider.tsx
+++ b/client/src/store/AuthProvider.tsx
@@ -1,23 +1,33 @@
 'use client';
 
 import { supabase } from '@/utils/supabase/client';
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { storeLogin, storeLogout } from './authSlice';
 import { useToast } from '@/hooks/useToast';
 
 export default function AuthProvider() {
   const dispatch = useDispatch();
+  const isInitialized = useRef(false);
+  const lastUserId = useRef<string | null>(null);
   const firstMount = useRef(true);
   const { toast } = useToast();
+  const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isClient) return;
+
     const checkSession = async () => {
       const {
         data: { session }
       } = await supabase.auth.getSession();
 
       if (session) {
+        lastUserId.current = session.user.id;
         dispatch(
           storeLogin({
             userId: session.user.id,
@@ -25,8 +35,11 @@ export default function AuthProvider() {
           })
         );
       } else {
+        lastUserId.current = null;
         dispatch(storeLogout());
       }
+
+      isInitialized.current = true;
     };
 
     checkSession();
@@ -34,6 +47,11 @@ export default function AuthProvider() {
     // 실시간 세션 감지
     const { data: listener } = supabase.auth.onAuthStateChange(
       (_event, session) => {
+        if (!isInitialized.current) return;
+
+        const currentUserId = session?.user.id || null;
+        const userChanged = lastUserId.current !== currentUserId;
+
         if (session) {
           dispatch(
             storeLogin({
@@ -41,18 +59,20 @@ export default function AuthProvider() {
               email: session.user.email ?? null
             })
           );
-          if (!firstMount.current) {
+          if (!firstMount.current && userChanged) {
             toast({
               description: '로그인 되었습니다.'
             });
           }
+          lastUserId.current = currentUserId;
         } else {
           dispatch(storeLogout());
-          if (!firstMount.current) {
+          if (!firstMount.current && userChanged) {
             toast({
               description: '로그아웃 되었습니다.'
             });
           }
+          lastUserId.current = null;
         }
 
         firstMount.current = false;
@@ -62,7 +82,7 @@ export default function AuthProvider() {
     return () => {
       listener.subscription.unsubscribe();
     };
-  }, [dispatch]);
+  }, [dispatch, toast, isClient]);
 
   return null;
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] toast 중복 알림 제거

## 💡 자세한 설명
page focus 가 변경될때마다 session의 값을 체크하고 toast를 보내줬기때문에 초기화 상태관리와 사용자 변경 감지 후 
실제 사용자 변경이 감지되었을때만 toast가 출력되게 수정했습니다

AuthProvider.tsx

## ✅ 셀프 체크리스트

- [x] PR 제목을 형식에 맞게 작성했나요?
- [x] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [x] 테스트는 잘 통과했나요?
- [x] 불필요한 코드는 제거했나요?

closes #120 
