### PR TITLE
fix: 알림 재설정 모달 오류 수정

### DIFF
--- a/client/src/shared/ui/ConfirmDialog.tsx
+++ b/client/src/shared/ui/ConfirmDialog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
+import { createPortal } from 'react-dom';
 import { cn } from '@/shared/lib/utils';
 import { useFocusTrap } from '@/shared/lib/a11y';
 import { FOCUS_RING } from '@/shared/lib/component-utils';
@@ -44,7 +45,7 @@ export function ConfirmDialog({
 
   if (!isOpen) return null;
 
-  return (
+  const dialog = (
     <div
       className="fixed inset-0 bg-black/80 backdrop-blur-sm flex items-center justify-center z-modal-backdrop"
       role="dialog"
@@ -54,7 +55,7 @@ export function ConfirmDialog({
     >
       <div
         ref={dialogRef}
-        className="bg-dark-card border-2 border-coral rounded-2xl p-6 sm:p-8 w-[20rem] sm:w-[28rem] mx-4 animate-scale-in shadow-[0_8px_32px_rgba(0,0,0,0.6)]"
+        className="relative z-modal bg-dark-card border-2 border-coral rounded-2xl p-6 sm:p-8 w-[20rem] sm:w-[28rem] mx-4 animate-scale-in shadow-[0_8px_32px_rgba(0,0,0,0.6)]"
         onClick={(e) => e.stopPropagation()}
       >
         <div className="flex items-center justify-between mb-4">
@@ -110,4 +111,8 @@ export function ConfirmDialog({
       </div>
     </div>
   );
+
+  if (typeof document === 'undefined') return null;
+
+  return createPortal(dialog, document.body);
 }

--- a/client/src/shared/ui/dropdown.tsx
+++ b/client/src/shared/ui/dropdown.tsx
@@ -213,7 +213,7 @@ const Dropdown = ({ isOpen = false }: DropdownProps) => {
               border: '1px solid var(--dropdown-border)',
               borderRadius: '8px',
               boxShadow: 'var(--dropdown-shadow)',
-              zIndex: 9999,
+              zIndex: 'var(--z-dropdown)',
               overflow: 'hidden'
             }}
             role="menu"
@@ -359,6 +359,7 @@ const Dropdown = ({ isOpen = false }: DropdownProps) => {
                   >
                     <button
                       onClick={() => {
+                        setOpen(false);
                         setShowConfirmDialog(true);
                       }}
                       style={{


### PR DESCRIPTION
## 💡 작업 내용

- [x] 모달 위치 수정

## 💡 자세한 설명
`알림 재설정` 확인 모달이 헤더/드롭다운 뒤에 깔리는 문제를 수정했습니다.

  기존에는 `ConfirmDialog`가 `Dropdown` 내부에서 렌더링되고 있었고, `Dropdown`은 sticky 헤더 안에 위치해 있었습
  니다. 헤더는 `z-index`를 가진 레이어를 만들 수 있기 때문에, 모달이 `fixed inset-0`이어도 헤더의 레이어 구조에
  영향을 받았습니다. 반면 드롭다운 메뉴는 `document.body`에 portal로 렌더링되면서 `zIndex: 9999`를 사용하고 있어
  모달보다 위에 표시될 수 있었습니다.

  이를 해결하기 위해 `ConfirmDialog`를 `createPortal`로 `document.body`에 렌더링하도록 변경했습니다. 모달을 앱
  최상위 레이어에 배치해 헤더의 stacking context 영향을 받지 않게 했습니다.

  추가로 드롭다운의 `zIndex: 9999` 하드코딩을 제거하고 기존 z-index 토큰인 `var(--z-dropdown)`을 사용하도록 변경
  했습니다. 알림 재설정 버튼 클릭 시에는 드롭다운을 먼저 닫은 뒤 모달을 열도록 처리했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## 🚩 후속 작업 (선택)

## ✅ 셀프 체크리스트

- [ ] PR 제목을 형식에 맞게 작성했나요?
- [ ] 브랜치 전략에 맞는 브랜치에 PR을 올리고 있나요? (master/main이 아닙니다.)
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 작업 도중 문서 수정이 필요한 경우 잘 수정했나요?
- [ ] 테스트는 잘 통과했나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호
